### PR TITLE
Chore: update codecov gh action

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -51,7 +51,6 @@ jobs:
         directory: ./coveragereport/
         flags: unittests
         name: 'Degiro Bookkeeper coverage'
-        path_to_write_report: ./coveragereport/codecov_report.txt
         verbose: true
         
   publish:


### PR DESCRIPTION
Due to this: https://about.codecov.io/blog/codecov-uploader-deprecation-plan/