### PR TITLE
A couple of fixes

### DIFF
--- a/src/Degiro.Account/Degiro.fs
+++ b/src/Degiro.Account/Degiro.fs
@@ -9,7 +9,7 @@ open FSharp.Data
 module Account =
 
     let txnDescriptionRegExp =
-        "^(Buy|Sell) (\d+) .+?(?=@)@([\d\.\d]+) (EUR|USD)"
+        "^(Buy|Sell) (\d+) .+?(?=@)@([\.,\d]+) (EUR|USD)"
 
     let etfDescriptionMarkers = ["ETF"; "STOXX"; "SPDR S&P"; "ISHARES"; "EQQQ"; "VANGUARD"; "LYXOR"]
 
@@ -84,7 +84,7 @@ module Account =
                     Regex.Match(row.Description, txnDescriptionRegExp)
 
                 (decimal matches.Groups[2].Value)
-                * (decimal matches.Groups[3].Value)
+                * (Decimal.Parse(matches.Groups[3].Value))
 
             let getTotQuantity (rows: seq<Row>) (filter: Row -> bool) =
                 rows

--- a/src/Degiro.Account/Output.fs
+++ b/src/Degiro.Account/Output.fs
@@ -60,10 +60,14 @@ module CliOutput =
         earnings |> List.iter getEarningLine
 
         let periodTotalEarnings =
-            earnings |> List.sumBy (fun x -> x.Value)
+            match earnings.Length with
+            | 0 -> 0.0m
+            | _ -> earnings |> List.sumBy (fun x -> x.Value)
 
         let periodAvgPercEarnings =
-            earnings |> List.averageBy (fun x -> x.Percent)
+            match earnings.Length with
+            | 0 -> 0.0m
+            | _ -> earnings |> List.averageBy (fun x -> x.Percent)
 
         sb.AppendLine() |> ignore
 


### PR DESCRIPTION
 - Degiro account statements uses comma as thousands separator for unit price in "description row" of a transaction. The regular expression for the description row wasn't handling it correctly (thanks Andrew for the bug report!)
 - in case of no ETF earnings, it was quitting with an error before printing the cli output