### PR TITLE
fix: handles ISIN changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ OPTIONS:
  - output summary of deposits and withdrawals both total and per-year
  - output total ADR fees for a given year in $
  - output and take into account stock splits
+ - output and take into account changes in stock name or ISIN
  - country-specific features:
    - Ireland: support for CGT tax periods (i.e. Initial and Later - see revenue.ie)
 

--- a/src/Degiro.Account/Degiro.fs
+++ b/src/Degiro.Account/Degiro.fs
@@ -13,7 +13,7 @@ module Account =
         "^(?:STOCK SPLIT: |)(?:ISIN CHANGE: |)(Buy|Sell) (\d+) .+?(?=@)@([\.,\d]+)[ ]*(EUR|USD|)"
 
     let etfDescriptionMarkers =
-        [ "ETF"; "STOXX"; "SPDR S&P"; "ISHARES"; "EQQQ"; "VANGUARD"; "LYXOR" ]
+        [ " ETF"; "STOXX"; "SPDR S&P"; "ISHARES"; "EQQQ"; "VANGUARD"; "LYXOR" ]
 
     [<Literal>]
     let accountStatementSampleCsv =
@@ -177,21 +177,22 @@ module Account =
         |> List.sortByDescending (fun x -> x.Date)
 
 
-    /// Return a map containing all StockSplits indexed by their ISIN after the split
-    let getSplits (rows: seq<Row>) : Map<string, StockSplit> =
-        let splitRowGroups =
+    /// Return a map containing all StockChange indexed by their ISIN after the split
+    let getStockChanges (rows: seq<Row>) : Map<string, StockChange> =
+        let changeRowGroups =
             rows
-            |> Seq.filter (fun x -> x.Description.StartsWith "STOCK SPLIT:")
+            |> Seq.filter (fun x -> x.Description.StartsWith "STOCK SPLIT:" ||
+                                        x.Description.StartsWith "ISIN CHANGE:")
             |> Seq.groupBy (fun x -> x.Date.ToString() + x.Time.ToString())
 
-        let createSplit (splitRows: seq<Row>) =
+        let createStockChange (changeRows: seq<Row>) =
             let rowSell =
-                splitRows
+                changeRows
                 |> Seq.filter (fun row -> row.Description.Contains "Sell")
                 |> Seq.exactlyOne
 
             let rowBuy =
-                splitRows
+                changeRows
                 |> Seq.filter (fun row -> row.Description.Contains "Buy")
                 |> Seq.exactlyOne
 
@@ -211,38 +212,38 @@ module Account =
               ProductAfter = rowBuy.Product
               Multiplier = multiplier }
 
-        let splits: seq<StockSplit> =
-            splitRowGroups |> Seq.map (fun splitGroup -> createSplit (snd splitGroup))
+        let changes: seq<StockChange> =
+            changeRowGroups |> Seq.map (fun changeGroup -> createStockChange (snd changeGroup))
 
-        let folder (splitMap: Map<string, StockSplit>) (split: StockSplit) =
-            splitMap |> Map.add split.IsinAfter split
+        let folder (changeMap: Map<string, StockChange>) (change: StockChange) =
+            changeMap |> Map.add change.IsinAfter change
 
-        splits |> Seq.fold folder Map.empty<string, StockSplit>
+        changes |> Seq.fold folder Map.empty<string, StockChange>
 
 
-    /// Get all buy transactions preceding a given sell transactions (taking into account splits)
-    let getBuyTxnsPrecedingSell (txns: list<Txn>) (splits: Map<string, StockSplit>) (sellTxn: Txn) : list<Txn> =
+    /// Get all buy transactions preceding a given sell transactions (taking into account stock changes)
+    let getBuyTxnsPrecedingSell (txns: list<Txn>) (stockChanges: Map<string, StockChange>) (sellTxn: Txn) : list<Txn> =
 
         let buysPrecedingSell =
             txns
             |> List.filter (fun x -> x.Type = Buy && x.Date < sellTxn.Date && x.ISIN = sellTxn.ISIN)
             |> List.sortByDescending (fun x -> x.Date)
 
-        if splits.ContainsKey sellTxn.ISIN then
+        if stockChanges.ContainsKey sellTxn.ISIN then
 
-            let split = splits.[sellTxn.ISIN]
+            let stockChange = stockChanges.[sellTxn.ISIN]
 
-            let buysPrecedingSellBeforeSplit =
+            let buysPrecedingSellBeforeStockChange =
                 txns
-                |> List.filter (fun x -> x.Type = Buy && x.Date < sellTxn.Date && x.ISIN = split.IsinBefore)
+                |> List.filter (fun x -> x.Type = Buy && x.Date < sellTxn.Date && x.ISIN = stockChange.IsinBefore)
                 |> List.map (fun x ->
                     { x with
-                        Product = split.ProductAfter
-                        ISIN = split.IsinAfter
-                        Value = x.Value * (decimal split.Multiplier)
-                        Quantity = x.Quantity / split.Multiplier })
+                        Product = stockChange.ProductAfter
+                        ISIN = stockChange.IsinAfter
+                        Value = x.Value * (decimal stockChange.Multiplier)
+                        Quantity = x.Quantity / stockChange.Multiplier })
 
-            buysPrecedingSell @ buysPrecedingSellBeforeSplit
+            buysPrecedingSell @ buysPrecedingSellBeforeStockChange
             |> List.sortByDescending (fun x -> x.Date)
         else
             buysPrecedingSell
@@ -251,9 +252,9 @@ module Account =
     /// For a given Sell transaction, compute its earning by
     /// going back in time to as many Buy transactions as required to match the quantity sold
     //  FIXME: make it comply with Irish CGT FIFO rule
-    let computeEarning (txns: list<Txn>) (splits: Map<string, StockSplit>) (sellTxn: Txn) =
+    let computeEarning (txns: list<Txn>) (stockChanges: Map<string, StockChange>) (sellTxn: Txn) =
 
-        let buysPrecedingSell = getBuyTxnsPrecedingSell txns splits sellTxn
+        let buysPrecedingSell = getBuyTxnsPrecedingSell txns stockChanges sellTxn
 
         let rec getTotBuyPrice (buys: list<Txn>) (quantityToSell: int) (totBuyPrice: decimal) =
             if quantityToSell = 0 then
@@ -280,10 +281,10 @@ module Account =
 
 
     /// Return the Earning objects for a given sequence of sells
-    let getSellsEarnings (sells: list<Txn>) (allTxns: list<Txn>) (splits: Map<string, StockSplit>) : list<Earning> =
+    let getSellsEarnings (sells: list<Txn>) (allTxns: list<Txn>) (stockChanges: Map<string, StockChange>) : list<Earning> =
         sells
         |> List.map (fun sell ->
-            let earning, earningPercentage = computeEarning allTxns splits sell
+            let earning, earningPercentage = computeEarning allTxns stockChanges sell
 
             { Date = sell.Date
               Product = sell.Product

--- a/src/Degiro.Account/Model.fs
+++ b/src/Degiro.Account/Model.fs
@@ -69,7 +69,8 @@ type Period =
     | Later = 2
     | All = 3
 
-type StockSplit =
+/// Models stock splits, ISIN or name changes
+type StockChange =
     { Date: DateTime
       IsinBefore: string
       IsinAfter: string

--- a/src/Degiro.Account/Model.fs
+++ b/src/Degiro.Account/Model.fs
@@ -10,7 +10,9 @@ module Utils =
 
     // Create discriminated unions from string - http://fssnip.net/9l
     let fromString<'a> (s: string) =
-        match FSharpType.GetUnionCases typeof<'a> |> Array.filter (fun case -> case.Name = s) with
+        match FSharpType.GetUnionCases typeof<'a>
+              |> Array.filter (fun case -> case.Name = s)
+            with
         | [| case |] -> FSharpValue.MakeUnion(case, [||]) :?> 'a
         | _ -> failwith (s + " not recognized as a valid parameter.")
 

--- a/src/Degiro.Account/Output.fs
+++ b/src/Degiro.Account/Output.fs
@@ -50,7 +50,7 @@ module CliOutput =
         sb.AppendLine $"""%-10s{"Date"} %-40s{"Product"} %9s{"P/L (€)"} %8s{"P/L %"}"""
         |> ignore
 
-        sb.AppendLine $"""%s{String.replicate 68 "─"}""" |> ignore
+        sb.AppendLine $"""%s{String.replicate 70 "─"}""" |> ignore
 
         let getEarningLine (e: Earning) =
             sb.AppendLine $"""%s{e.Date.ToString("yyyy-MM-dd")} %-40s{e.Product} %9.2f{e.Value} %7.1f{e.Percent}%%"""
@@ -81,7 +81,7 @@ module CliOutput =
         sb.AppendLine $"""%-40s{"Product"} %9s{"Tax"} %9s{"Value"} %8s{"Currency"}"""
         |> ignore
 
-        sb.AppendLine $"""%s{String.replicate 65 "─"}""" |> ignore
+        sb.AppendLine $"""%s{String.replicate 69 "─"}""" |> ignore
 
         let getDividentLine (d: Dividend) =
             sb.AppendLine $"%-40s{d.Product} %9.2f{d.ValueTax} %9.2f{d.Value} %8A{d.Currency}"
@@ -108,7 +108,7 @@ module CliOutput =
         sb.ToString()
 
     let getStockChangesCliString (stockChanges: seq<StockChange>) =
-        let sortedStockChanges = stockChanges |> Seq.sortBy (fun x -> x.Date)
+        let sortedStockChanges = stockChanges |> Seq.sortByDescending (fun x -> x.Date)
         let sb = StringBuilder()
 
         sb.AppendLine $"""%-10s{"Date"} %-13s{"ISIN Before"} %-13s{"ISIN After"} %-40s{"Product Name Before"} %-40s{"Product Name After"} %-10s{"Multiplier"}"""

--- a/src/Degiro.Account/Output.fs
+++ b/src/Degiro.Account/Output.fs
@@ -50,7 +50,8 @@ module CliOutput =
         sb.AppendLine $"""%-10s{"Date"} %-40s{"Product"} %9s{"P/L (€)"} %8s{"P/L %"}"""
         |> ignore
 
-        sb.AppendLine $"""%s{String.replicate 70 "─"}""" |> ignore
+        sb.AppendLine $"""%s{String.replicate 70 "─"}"""
+        |> ignore
 
         let getEarningLine (e: Earning) =
             sb.AppendLine $"""%s{e.Date.ToString("yyyy-MM-dd")} %-40s{e.Product} %9.2f{e.Value} %7.1f{e.Percent}%%"""
@@ -70,8 +71,11 @@ module CliOutput =
 
         sb.AppendLine() |> ignore
 
-        sb.AppendLine $"""Tot. P/L (€): %.2f{periodTotalEarnings}""" |> ignore
-        sb.AppendLine $"""Avg %% P/L: %.2f{periodAvgPercEarnings}%%""" |> ignore
+        sb.AppendLine $"""Tot. P/L (€): %.2f{periodTotalEarnings}"""
+        |> ignore
+
+        sb.AppendLine $"""Avg %% P/L: %.2f{periodAvgPercEarnings}%%"""
+        |> ignore
 
         sb.ToString()
 
@@ -81,7 +85,8 @@ module CliOutput =
         sb.AppendLine $"""%-40s{"Product"} %9s{"Tax"} %9s{"Value"} %8s{"Currency"}"""
         |> ignore
 
-        sb.AppendLine $"""%s{String.replicate 69 "─"}""" |> ignore
+        sb.AppendLine $"""%s{String.replicate 69 "─"}"""
+        |> ignore
 
         let getDividentLine (d: Dividend) =
             sb.AppendLine $"%-40s{d.Product} %9.2f{d.ValueTax} %9.2f{d.Value} %8A{d.Currency}"
@@ -108,13 +113,18 @@ module CliOutput =
         sb.ToString()
 
     let getStockChangesCliString (stockChanges: seq<StockChange>) =
-        let sortedStockChanges = stockChanges |> Seq.sortByDescending (fun x -> x.Date)
+        let sortedStockChanges =
+            stockChanges
+            |> Seq.sortByDescending (fun x -> x.Date)
+
         let sb = StringBuilder()
 
-        sb.AppendLine $"""%-10s{"Date"} %-13s{"ISIN Before"} %-13s{"ISIN After"} %-40s{"Product Name Before"} %-40s{"Product Name After"} %-10s{"Multiplier"}"""
+        sb.AppendLine
+            $"""%-10s{"Date"} %-13s{"ISIN Before"} %-13s{"ISIN After"} %-40s{"Product Name Before"} %-40s{"Product Name After"} %-10s{"Multiplier"}"""
         |> ignore
 
-        sb.AppendLine $"""%s{String.replicate 131 "─"}""" |> ignore
+        sb.AppendLine $"""%s{String.replicate 131 "─"}"""
+        |> ignore
 
         let getChangeLine (s: StockChange) =
             sb.AppendLine

--- a/src/Degiro.Account/Output.fs
+++ b/src/Degiro.Account/Output.fs
@@ -47,13 +47,13 @@ module CliOutput =
     let getEarningsCliString (earnings: Earning list) =
         let sb = StringBuilder()
 
-        sb.AppendLine $"""%-10s{"Date"} %-40s{"Product"} %7s{"P/L (€)"} %8s{"P/L %"}"""
+        sb.AppendLine $"""%-10s{"Date"} %-40s{"Product"} %9s{"P/L (€)"} %8s{"P/L %"}"""
         |> ignore
 
         sb.AppendLine $"""%s{String.replicate 68 "─"}""" |> ignore
 
         let getEarningLine (e: Earning) =
-            sb.AppendLine $"""%s{e.Date.ToString("yyyy-MM-dd")} %-40s{e.Product} %7.2f{e.Value} %7.1f{e.Percent}%%"""
+            sb.AppendLine $"""%s{e.Date.ToString("yyyy-MM-dd")} %-40s{e.Product} %9.2f{e.Value} %7.1f{e.Percent}%%"""
             |> ignore
 
         earnings |> List.iter getEarningLine
@@ -78,13 +78,13 @@ module CliOutput =
     let getDividendsCliString (dividends: Dividend list) =
         let sb = StringBuilder()
 
-        sb.AppendLine $"""%-40s{"Product"} %7s{"Tax"} %7s{"Value"} %8s{"Currency"}"""
+        sb.AppendLine $"""%-40s{"Product"} %9s{"Tax"} %9s{"Value"} %8s{"Currency"}"""
         |> ignore
 
         sb.AppendLine $"""%s{String.replicate 65 "─"}""" |> ignore
 
         let getDividentLine (d: Dividend) =
-            sb.AppendLine $"%-40s{d.Product} %7.2f{d.ValueTax} %7.2f{d.Value} %8A{d.Currency}"
+            sb.AppendLine $"%-40s{d.Product} %9.2f{d.ValueTax} %9.2f{d.Value} %8A{d.Currency}"
             |> ignore
 
         dividends |> List.iter getDividentLine
@@ -107,19 +107,20 @@ module CliOutput =
 
         sb.ToString()
 
-    let getSplitCliString (splits: seq<StockSplit>) =
+    let getStockChangesCliString (stockChanges: seq<StockChange>) =
+        let sortedStockChanges = stockChanges |> Seq.sortBy (fun x -> x.Date)
         let sb = StringBuilder()
 
-        sb.AppendLine $"""%-10s{"Date"} %-15s{"ISIN Before"} %-15s{"ISIN After"} %-40s{"Product"} %-10s{"Multiplier"}"""
+        sb.AppendLine $"""%-10s{"Date"} %-13s{"ISIN Before"} %-13s{"ISIN After"} %-40s{"Product Name Before"} %-40s{"Product Name After"} %-10s{"Multiplier"}"""
         |> ignore
 
-        sb.AppendLine $"""%s{String.replicate 94 "─"}""" |> ignore
+        sb.AppendLine $"""%s{String.replicate 131 "─"}""" |> ignore
 
-        let getSplitLine (s: StockSplit) =
+        let getChangeLine (s: StockChange) =
             sb.AppendLine
-                $"""%-10s{s.Date.ToString("yyyy-MM-dd")} %-15s{s.IsinBefore} %-15s{s.IsinAfter} %-40s{s.ProductAfter} %10d{s.Multiplier}"""
+                $"""%-10s{s.Date.ToString("yyyy-MM-dd")} %-13s{s.IsinBefore} %-13s{s.IsinAfter} %-40s{s.ProductBefore} %-40s{s.ProductAfter} %10d{s.Multiplier}"""
             |> ignore
 
-        splits |> Seq.iter getSplitLine
+        sortedStockChanges |> Seq.iter getChangeLine
 
         sb.ToString()

--- a/src/Degiro.Cli/Main.fs
+++ b/src/Degiro.Cli/Main.fs
@@ -9,7 +9,11 @@ open Degiro.Account
 open Degiro.CliOutput
 open Degiro.CsvOutput
 
-let VERSION = Assembly.GetExecutingAssembly().GetName().Version.ToString()
+let VERSION =
+    Assembly
+        .GetExecutingAssembly()
+        .GetName()
+        .Version.ToString()
 
 let PROGRAM_NAME = AppDomain.CurrentDomain.FriendlyName
 
@@ -72,7 +76,9 @@ let main argv =
         let cleanCsv, isMalformed = cleanCsv originalCsvContent
 
         if isMalformed then
-            let newFilePath = csvFilePath[.. csvFilePath.Length - 5] + "-clean.csv"
+            let newFilePath =
+                csvFilePath[.. csvFilePath.Length - 5]
+                + "-clean.csv"
 
             File.WriteAllText(newFilePath, cleanCsv)
             printfn $"Cleaned CSV file has been written to {newFilePath}.\n"
@@ -101,9 +107,12 @@ let main argv =
             printfn $"No sells recorded in %d{year}, period: %A{period}."
         else
             let sellsSharesInPeriod =
-                sellsInPeriod |> List.filter (fun x -> x.ProdType = Shares)
+                sellsInPeriod
+                |> List.filter (fun x -> x.ProdType = Shares)
 
-            let sellsETFInPeriod = sellsInPeriod |> List.filter (fun x -> x.ProdType = ETF)
+            let sellsETFInPeriod =
+                sellsInPeriod
+                |> List.filter (fun x -> x.ProdType = ETF)
 
             let earningsSharesInPeriod = getSellsEarnings sellsSharesInPeriod txns stockChanges
 
@@ -165,7 +174,8 @@ let main argv =
 #if DEBUG
         printfn $"\nElapsed time: {timer.ElapsedMilliseconds} ms"
 #endif
-    with ex ->
+    with
+    | ex ->
         eprintfn $"Error: %s{ex.Message}\n%s{ex.StackTrace}"
         Environment.Exit 1
 

--- a/src/Degiro.Cli/Main.fs
+++ b/src/Degiro.Cli/Main.fs
@@ -88,11 +88,11 @@ let main argv =
 
         let txns = Seq.map buildTxn txnsGrouped |> Seq.toList
 
-        let splits = getSplits rows
+        let stockChanges = getStockChanges rows
 
-        if not (Map.isEmpty splits) then
-            printfn "🖋  The Account Statement reports the following stock splits:\n"
-            printfn $"%s{getSplitCliString splits.Values}\n"
+        if not (Map.isEmpty stockChanges) then
+            printfn "🖋  The Account Statement reports the following stock splits, ISIN or product name changes:\n"
+            printfn $"%s{getStockChangesCliString stockChanges.Values}\n"
 
         let sellsInPeriod = getSellTxnsInPeriod txns year period
 
@@ -105,12 +105,12 @@ let main argv =
 
             let sellsETFInPeriod = sellsInPeriod |> List.filter (fun x -> x.ProdType = ETF)
 
-            let earningsSharesInPeriod = getSellsEarnings sellsSharesInPeriod txns splits
+            let earningsSharesInPeriod = getSellsEarnings sellsSharesInPeriod txns stockChanges
 
             printfn $"💰 Earnings from shares in {year}, period %A{period}:\n"
             printfn $"%s{getEarningsCliString earningsSharesInPeriod}"
 
-            let earningsETFInPeriod = getSellsEarnings sellsETFInPeriod txns splits
+            let earningsETFInPeriod = getSellsEarnings sellsETFInPeriod txns stockChanges
             printfn $"\n💰 Earnings from ETF in {year}, period %A{period}:\n"
             printfn $"%s{getEarningsCliString earningsETFInPeriod}"
 

--- a/test/AccountTests.fs
+++ b/test/AccountTests.fs
@@ -90,7 +90,10 @@ module AccountTests =
     [<Test>]
     let ``BuildTxn with ETF`` () =
         let realEtfDescr =
-            [ "VANGUARD FTSE AW"; "SPDR S&P 500"; "ISHARES S&P 500"; "LYXOR ETF CAC 40" ]
+            [ "VANGUARD FTSE AW"
+              "SPDR S&P 500"
+              "ISHARES S&P 500"
+              "LYXOR ETF CAC 40" ]
 
         let rndEtfDesc = realEtfDescr[Random().Next(realEtfDescr.Length)]
 
@@ -211,11 +214,14 @@ module AccountTests =
         let rows = AccountCsv.Parse(testRows).Rows
         getTotalDeposits rows |> should equal 2200.0
 
-        getTotalYearDeposits rows 2019 |> should equal 1000.0
+        getTotalYearDeposits rows 2019
+        |> should equal 1000.0
 
-        getTotalYearDeposits rows 2020 |> should equal 500.0
+        getTotalYearDeposits rows 2020
+        |> should equal 500.0
 
-        getTotalYearDeposits rows 2021 |> should equal 700.0
+        getTotalYearDeposits rows 2021
+        |> should equal 700.0
 
 
     [<Test>]
@@ -238,13 +244,18 @@ module AccountTests =
         30-06-2020,10:50,30-06-2020,,,flatex Deposit,,EUR,500.00,EUR,1051.56,"""
 
         let rows = AccountCsv.Parse(testRows).Rows
-        getTotalWithdrawals rows |> should equal (500.0 + 1540.0 + 1000.0)
 
-        getTotalYearWithdrawals rows 2015 |> should equal 500.0
+        getTotalWithdrawals rows
+        |> should equal (500.0 + 1540.0 + 1000.0)
 
-        getTotalYearWithdrawals rows 2016 |> should equal 1540.0
+        getTotalYearWithdrawals rows 2015
+        |> should equal 500.0
 
-        getTotalYearWithdrawals rows 2019 |> should equal 1000.0
+        getTotalYearWithdrawals rows 2016
+        |> should equal 1540.0
+
+        getTotalYearWithdrawals rows 2019
+        |> should equal 1000.0
 
 
     [<Test>]
@@ -313,13 +324,20 @@ module AccountTests =
                 Quantity = 4
                 Date = DateTime(2020, 12, 1) }
 
-        let allTxns = [ txnBuyA1; txnBuyA2; txnBuyB1; txnSellA1 ]
+        let allTxns =
+            [ txnBuyA1
+              txnBuyA2
+              txnBuyB1
+              txnSellA1 ]
 
-        getSellTxnsInPeriod allTxns 2019 Period.Initial |> should be Empty
+        getSellTxnsInPeriod allTxns 2019 Period.Initial
+        |> should be Empty
 
-        getSellTxnsInPeriod allTxns 2020 Period.Initial |> should be Empty
+        getSellTxnsInPeriod allTxns 2020 Period.Initial
+        |> should be Empty
 
-        getSellTxnsInPeriod allTxns 2020 Period.Later |> should equal [ txnSellA1 ]
+        getSellTxnsInPeriod allTxns 2020 Period.Later
+        |> should equal [ txnSellA1 ]
 
         let expectedEarning =
             { Date = txnSellA1.Date
@@ -367,7 +385,8 @@ module AccountTests =
 
         let sellTxns = getSellTxnsInPeriod allTnxs 2020 Period.All
 
-        getSellsEarnings sellTxns allTnxs Map.empty |> should equal [ expectedEarning ]
+        getSellsEarnings sellTxns allTnxs Map.empty
+        |> should equal [ expectedEarning ]
 
 
     [<Test>]
@@ -462,7 +481,8 @@ module AccountTests =
               Value = (86.43m - 184.58m)
               Percent = Math.Round(((86.43m - 184.58m) / 184.58m) * 100.0m, 2) }
 
-        getSellsEarnings sellTxns txns splits |> should equal [ expectedEarning ]
+        getSellsEarnings sellTxns txns splits
+        |> should equal [ expectedEarning ]
 
 
     [<Test>]
@@ -492,14 +512,15 @@ module AccountTests =
         isinChanges |> should haveCount 1
 
         let expectedEarning =
-            { Date = DateTime(2022, 10, 17, 17, 01, 0)
+            { Date = DateTime(2022, 10, 17, 17, 1, 0)
               Product = "ACME NEW NAME"
               ISIN = "CODENEW123456"
               ProdType = Shares
               Value = (229.17m - 223.06m)
               Percent = Math.Round(((229.17m - 223.06m) / 223.06m) * 100.0m, 2) }
 
-        getSellsEarnings sellTxns txns isinChanges |> should equal [ expectedEarning ]
+        getSellsEarnings sellTxns txns isinChanges
+        |> should equal [ expectedEarning ]
 
 
     [<Test>]
@@ -522,7 +543,8 @@ module AccountTests =
                    ProductAfter = "ACME Inc NEW"
                    Multiplier = 10 })]
 
-        stockChanges |> should equal expectedStockChangeMap
+        stockChanges
+        |> should equal expectedStockChangeMap
 
 
     [<Test>]

--- a/test/AccountTests.fs
+++ b/test/AccountTests.fs
@@ -437,7 +437,7 @@ module AccountTests =
         txns |> should haveLength 2
 
         let sellTxns = getSellTxnsInPeriod txns 2022 Period.All
-        let splits = getSplits rows
+        let splits = getStockChanges rows
         splits |> should haveCount 1
 
         let expectedEarning =
@@ -452,7 +452,7 @@ module AccountTests =
 
 
     [<Test>]
-    let ``Create Splits`` () =
+    let ``Create StockChange`` () =
         let testRows =
             header
             + """
@@ -460,9 +460,9 @@ module AccountTests =
         06-06-2022,14:38,06-06-2022,ACME Inc OLD,CODEOLD123456,STOCK SPLIT: Sell 50 ACME Inc OLD@1.75 USD (CODEOLD123456),,USD,87.50,USD,87.50,"""
 
         let rows = AccountCsv.Parse(testRows).Rows
-        let split = getSplits rows
+        let split = getStockChanges rows
 
-        let expectedSplitMap =
+        let expectedStockChangeMap =
             Map[("CODENEW123456",
                  { Date = DateTime(2022, 6, 6, 14, 38, 0)
                    IsinBefore = "CODEOLD123456"
@@ -471,7 +471,7 @@ module AccountTests =
                    ProductAfter = "ACME Inc NEW"
                    Multiplier = 10 })]
 
-        split |> should equal expectedSplitMap
+        split |> should equal expectedStockChangeMap
 
 
     [<Test>]

--- a/test/AccountTests.fs
+++ b/test/AccountTests.fs
@@ -488,8 +488,8 @@ module AccountTests =
         txns |> should haveLength 2
 
         let sellTxns = getSellTxnsInPeriod txns 2022 Period.All
-        let splits = getStockChanges rows
-        splits |> should haveCount 1
+        let isinChanges = getStockChanges rows
+        isinChanges |> should haveCount 1
 
         let expectedEarning =
             { Date = DateTime(2022, 10, 17, 17, 01, 0)
@@ -499,7 +499,7 @@ module AccountTests =
               Value = (229.17m - 223.06m)
               Percent = Math.Round(((229.17m - 223.06m) / 223.06m) * 100.0m, 2) }
 
-        getSellsEarnings sellTxns txns splits |> should equal [ expectedEarning ]
+        getSellsEarnings sellTxns txns isinChanges |> should equal [ expectedEarning ]
 
 
     [<Test>]

--- a/test/OutputTest.fs
+++ b/test/OutputTest.fs
@@ -129,8 +129,8 @@ ACME Inc B,ABC2,142.0,0.52,EUR
         outStr |> should contain expectedStr2
 
     [<TestCase>]
-    let ``Get splits CLI string`` () =
-        let split: StockSplit =
+    let ``Get stock change CLI string`` () =
+        let stockChange: StockChange =
             { Date = DateTime(2022, 03, 04)
               IsinBefore = "ABC-Before"
               IsinAfter = "ABC-After"
@@ -138,7 +138,7 @@ ACME Inc B,ABC2,142.0,0.52,EUR
               ProductAfter = "ABC"
               ProductBefore = "ABC Before" }
 
-        let outStr = getSplitCliString [| split |]
+        let outStr = getStockChangesCliString [| stockChange |]
 
         outStr |> should contain "ABC-After"
 

--- a/test/OutputTest.fs
+++ b/test/OutputTest.fs
@@ -36,12 +36,17 @@ module OutputTests =
 2021-01-02,ACME Inc B,ABC2,ETF,500.0,10.0
 """
 
-        earningsToCsvString [ earningOne; earningTwo ] |> should equal expectedStr
+        earningsToCsvString [ earningOne
+                              earningTwo ]
+        |> should equal expectedStr
 
     [<TestCase>]
     let ``Empty earnings list to CSV string`` () =
         earningsToCsvString List.empty
-        |> should equal ("Date,Product,ISIN,Type,Value,Percent" + Environment.NewLine)
+        |> should
+            equal
+            ("Date,Product,ISIN,Type,Value,Percent"
+             + Environment.NewLine)
 
 
     [<TestCase>]
@@ -68,13 +73,18 @@ ACME Inc A,ABC1,42.0,0.50,USD
 ACME Inc B,ABC2,142.0,0.52,EUR
 """
 
-        dividendsToCsvString [ dividendOne; dividendTwo ] |> should equal expectedStr
+        dividendsToCsvString [ dividendOne
+                               dividendTwo ]
+        |> should equal expectedStr
 
 
     [<TestCase>]
     let ``Empty dividends list to CSV string`` () =
         dividendsToCsvString List.Empty
-        |> should equal ("Product,ISIN,Value,Value Tax,Currency" + Environment.NewLine)
+        |> should
+            equal
+            ("Product,ISIN,Value,Value Tax,Currency"
+             + Environment.NewLine)
 
     [<TestCase>]
     let ``Get earnings CLI string`` () =
@@ -97,7 +107,9 @@ ACME Inc B,ABC2,142.0,0.52,EUR
         let expectedStr1 = "Tot. P/L (€): 150.00"
         let expectedStr2 = "Avg % P/L: 15.00%"
 
-        let outStr = getEarningsCliString [ earningOne; earningTwo ]
+        let outStr =
+            getEarningsCliString [ earningOne
+                                   earningTwo ]
 
         outStr |> should contain expectedStr1
         outStr |> should contain expectedStr2
@@ -123,7 +135,9 @@ ACME Inc B,ABC2,142.0,0.52,EUR
         let expectedStr1 = "Tot. net dividends in €: 1.50"
         let expectedStr2 = "Tot. net dividends in $: 4.50"
 
-        let outStr = getDividendsCliString [ dividendOne; dividendTwo ]
+        let outStr =
+            getDividendsCliString [ dividendOne
+                                    dividendTwo ]
 
         outStr |> should contain expectedStr1
         outStr |> should contain expectedStr2
@@ -131,7 +145,7 @@ ACME Inc B,ABC2,142.0,0.52,EUR
     [<TestCase>]
     let ``Get stock change CLI string`` () =
         let stockChange: StockChange =
-            { Date = DateTime(2022, 03, 04)
+            { Date = DateTime(2022, 3, 4)
               IsinBefore = "ABC-Before"
               IsinAfter = "ABC-After"
               Multiplier = 3


### PR DESCRIPTION
Handles ISIN changes using the existing logic for stock splits. `StockSplit` data structure is thus renamed and generalized as `StockChange`.

close #91 